### PR TITLE
iface-monitor: fix build test

### DIFF
--- a/iface-monitor/docker-build.conf
+++ b/iface-monitor/docker-build.conf
@@ -1,1 +1,1 @@
-TEST_CMD="python2 /interface-monitor.py --help"
+TEST_CMD="python /interface-monitor.py --help"


### PR DESCRIPTION
We moved the docker container from Python2 to Python3 recently and
never updated the test case.

Signed-off-by: Michael Scott <mike@foundries.io>