### PR TITLE
added k3s dockerapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,6 @@ sanity checks of platform functionality.
 Runs the chromium browser inside a container and displays a website.
 
 ## k3s
-Runs a minimal kubernetes installation using Rancher's k3s project.
+Runs a minimal kubernetes installation using Rancher's k3s project. 
+
+*NOTE: you may wish to review [Rancher's k3s minimum hardware requirements](https://rancher.com/docs/k3s/latest/en/installation/node-requirements/#hardware) to ensure you your device has memory to spare*

--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ sanity checks of platform functionality.
 
 ## x-kiosk
 Runs the chromium browser inside a container and displays a website.
+
+## k3s
+Runs a minimal kubernetes installation using Rancher's k3s project.

--- a/k3s.dockerapp
+++ b/k3s.dockerapp
@@ -1,0 +1,26 @@
+version: 0.9.1
+name: k3s
+description: "A minimalistic kubernetes installation using Rancher's k3s"
+---
+
+version: '3.2'
+services:
+  master:
+    image: rancher/k3s:v0.9.1
+    tmpfs:
+    - /run
+    - /var/run
+    privileged: true
+    command: server --no-deploy traefik
+    environment:
+    - "K3S_CLUSTER_SECRET=${K3S_CLUSTER_SECRET}"
+    - K3S_URL=https://master:6443
+    volumes:
+    - k3s-server:/var/lib/rancher/k3s
+    ports:
+    - 6443:6443
+volumes:
+  k3s-server: {}
+---
+
+K3S_CLUSTER_SECRET: somethingtotallyrandom


### PR DESCRIPTION
Adds [k3s](https://k3s.io) docker [app](https://docs.docker.com/app/working-with-app/).  Starting with most recent working release given [issue 970](https://github.com/rancher/k3s/issues/970) with v1.0.0 and v0.10.x releases 