### PR TITLE
k3s: using network host for arbitrary ports usage

### DIFF
--- a/k3s.dockerapp
+++ b/k3s.dockerapp
@@ -17,8 +17,7 @@ services:
     - K3S_URL=https://master:6443
     volumes:
     - k3s-server:/var/lib/rancher/k3s
-    ports:
-    - 6443:6443
+    network_mode: host
 volumes:
   k3s-server: {}
 ---


### PR DESCRIPTION
now allows for services orchestrated to be reached