### PR TITLE
Create awsiot-optee container

### DIFF
--- a/awsiot-optee/Dockerfile
+++ b/awsiot-optee/Dockerfile
@@ -1,0 +1,44 @@
+FROM alpine:3.15 as p11
+
+# A bit ahead of 3.17.0, to include support for secure element control (used by SE05X)
+ENV OPTEE_CLIENT_VER "9a337049c52495e5e16b4a94decaa3e58fce793e"
+
+WORKDIR /src
+
+# build TEE client and headers
+RUN apk add --virtual build-deps git build-base linux-headers
+RUN \
+	git clone https://github.com/OP-TEE/optee_client.git && \
+	cd optee_client && git checkout ${OPTEE_CLIENT_VER} && \
+	wget https://raw.githubusercontent.com/foundriesio/meta-lmp/mp-87/meta-lmp-base/recipes-security/optee/optee-client/0001-FIO-extras-pkcs11-change-UUID-to-avoid-conflict-with.patch && \
+	patch -p1 < 0001-FIO-extras-pkcs11-change-UUID-to-avoid-conflict-with.patch && \
+	make -C libteec/ && \
+	make -C libseteec && \
+	make -C libckteec
+
+# build libp11
+WORKDIR /src
+RUN apk add openssl-dev cjson-dev util-linux-dev
+RUN \
+	wget https://github.com/OpenSC/libp11/releases/download/libp11-0.4.11/libp11-0.4.11.tar.gz && \
+	tar xvzf libp11-0.4.11.tar.gz && \
+	cd libp11-0.4.11 && \
+	./configure && \
+	make && \
+	make install
+
+FROM alpine:3.15 as aws
+# build mosquitto with pkcs11
+RUN apk add --virtual build-deps build-base cmake git linux-headers python3 python3-dev py3-pip
+RUN pip3 install awsiotsdk==1.11.3
+
+FROM alpine:3.15
+RUN apk --no-cache add opensc openssl python3
+ADD ["https://www.websecurity.digicert.com/content/dam/websitesecurity/digitalassets/desktop/pdfs/roots/VeriSign-Class 3-Public-Primary-Certification-Authority-G5.pem", "/etc/aws-ca.pem"]
+COPY --from=p11 /src/optee_client/out/libteec/libteec.so* /usr/lib/
+COPY --from=p11 /src/optee_client/out/libseteec/libseteec.so* /usr/lib/
+COPY --from=p11 /src/optee_client/out/libckteec/libckteec.so* /usr/lib/
+COPY --from=aws /usr/lib/python3.9/site-packages /usr/lib/python3.9/site-packages
+
+COPY demo_pub.py /
+CMD "/demo_pub.py"

--- a/awsiot-optee/demo_pub.py
+++ b/awsiot-optee/demo_pub.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python3
+import json
+import os
+import subprocess
+from time import time
+from uuid import uuid4
+
+from awscrt import mqtt
+from awscrt import io
+from awsiot import mqtt_connection_builder
+
+PIN = os.environ.get("PKCS11_PIN", "87654321")
+LIB = os.environ.get("PKCS11_LIB", "/usr/lib/libckteec.so.0.1")
+TOPIC = os.environ.get("TOPIC", "se050/demo")
+
+# The slot 5 and pkey label are set by:
+# https://github.com/foundriesio/meta-lmp/pull/750/
+CERT_SLOT = os.environ.get("CERT_SLOT", "05")
+PKEY_LABEL = os.environ.get("PKEY_LABEL", "SE_83000044")
+
+ENDPOINT = os.environ["AWS_ENDPOINT"]
+
+
+def load_cert() -> bytes:
+    der = subprocess.check_output(
+        ["pkcs11-tool", f"--module={LIB}", "--read-object", "--type=cert", f"--id={CERT_SLOT}"]
+    )
+    pem = subprocess.check_output(["openssl", "x509", "-inform", "der"], input=der)
+    return pem
+
+
+def build_pkcs11_mqtt_connection(on_interrupted, on_resumed):
+    print("Loading client cert...")
+    cert_bytes = load_cert()
+
+    print(f"Loading PKCS#11 library '{LIB}'...")
+    pkcs11_lib = io.Pkcs11Lib(
+        file=LIB, behavior=io.Pkcs11Lib.InitializeFinalizeBehavior.STRICT
+    )
+
+    mqtt_connection = mqtt_connection_builder.mtls_with_pkcs11(
+        pkcs11_lib=pkcs11_lib,
+        user_pin=PIN,
+        private_key_label=PKEY_LABEL,
+        cert_bytes=cert_bytes,
+        endpoint=ENDPOINT,
+        on_connection_interrupted=on_interrupted,
+        on_connection_resumed=on_resumed,
+        client_id=str(uuid4()),
+        clean_session=False,
+        keep_alive_secs=30,
+    )
+    return mqtt_connection
+
+
+# Callback when connection is accidentally lost.
+def on_connection_interrupted(connection, error, **kwargs):
+    print("Connection interrupted. error: {}".format(error))
+
+
+# Callback when an interrupted connection is re-established.
+def on_connection_resumed(connection, return_code, session_present, **kwargs):
+    print(
+        "Connection resumed. return_code: {} session_present: {}".format(
+            return_code, session_present
+        )
+    )
+
+
+if __name__ == "__main__":
+    mqtt_connection = build_pkcs11_mqtt_connection(
+        on_connection_interrupted, on_connection_resumed
+    )
+
+    print(f"Connecting to {ENDPOINT}...")
+
+    connect_future = mqtt_connection.connect()
+
+    # Future.result() waits until a result is available
+    connect_future.result()
+    print("Connected!")
+
+    payload = json.dumps({"time": time()})
+    mqtt_connection.publish(topic=TOPIC, payload=payload, qos=mqtt.QoS.AT_LEAST_ONCE)
+
+    # Disconnect
+    print("Disconnecting...")
+    disconnect_future = mqtt_connection.disconnect()
+    disconnect_future.result()
+    print("Disconnected!")

--- a/ot-wpantund/Dockerfile
+++ b/ot-wpantund/Dockerfile
@@ -63,6 +63,7 @@ RUN cd ~/ && \
 	git clone --recursive https://github.com/openthread/borderrouter && \
 	cd borderrouter && \
 	git reset --hard f42c113f3bce40b7b0066af405b99fcf09f7c98c && \
+	git submodule update && \
 	./bootstrap && \
 	./configure && \
 	make && \


### PR DESCRIPTION
This container can be used on a platform like an imx8 with an SE050 HSM
and connect to AWS IOT's MQTT server via PKCS11/optee

Signed-off-by: Andy Doan <andy@foundries.io>