### PR TITLE
awsiot-optee: Various small fixes and improvements

### DIFF
--- a/awsiot-optee/Dockerfile
+++ b/awsiot-optee/Dockerfile
@@ -35,6 +35,9 @@ RUN pip3 install awsiotsdk==1.11.3
 FROM alpine:3.15
 RUN apk --no-cache add opensc openssl python3
 ADD ["https://www.websecurity.digicert.com/content/dam/websitesecurity/digitalassets/desktop/pdfs/roots/VeriSign-Class 3-Public-Primary-Certification-Authority-G5.pem", "/etc/aws-ca.pem"]
+ADD ["https://www.amazontrust.com/repository/AmazonRootCA3.pem", "https://www.amazontrust.com/repository/G2-RootCA3.pem", "https://www.amazontrust.com/repository/SFSRootCAG2.pem", "/etc/"]
+RUN cat /etc/AmazonRootCA3.pem /etc/G2-RootCA3.pem /etc/SFSRootCAG2.pem > /etc/aws-ca.chained
+
 COPY --from=p11 /src/optee_client/out/libteec/libteec.so* /usr/lib/
 COPY --from=p11 /src/optee_client/out/libseteec/libseteec.so* /usr/lib/
 COPY --from=p11 /src/optee_client/out/libckteec/libckteec.so* /usr/lib/

--- a/awsiot-optee/demo_pub.py
+++ b/awsiot-optee/demo_pub.py
@@ -12,6 +12,7 @@ from awsiot import mqtt_connection_builder
 PIN = os.environ.get("PKCS11_PIN", "87654321")
 LIB = os.environ.get("PKCS11_LIB", "/usr/lib/libckteec.so.0")
 TOPIC = os.environ.get("TOPIC", "se050/demo")
+AWS_CA =  os.environ.get("AWS_CA", "/etc/aws-ca.chained")
 
 # The slot 5 and pkey label are set by:
 # https://github.com/foundriesio/meta-lmp/pull/750/
@@ -49,6 +50,7 @@ def build_pkcs11_mqtt_connection(on_interrupted, on_resumed):
         client_id=str(uuid4()),
         clean_session=False,
         keep_alive_secs=30,
+        ca_filepath=AWS_CA,
     )
     return mqtt_connection
 

--- a/awsiot-optee/demo_pub.py
+++ b/awsiot-optee/demo_pub.py
@@ -23,10 +23,14 @@ ENDPOINT = os.environ["AWS_ENDPOINT"]
 
 
 def load_cert() -> bytes:
-    der = subprocess.check_output(
-        ["pkcs11-tool", f"--module={LIB}", "--read-object", "--type=cert", f"--id={CERT_SLOT}"]
+    p = subprocess.run(
+        ["pkcs11-tool", f"--module={LIB}", "--read-object", "--type=cert", f"--id={CERT_SLOT}"],
+        capture_output=True
     )
-    pem = subprocess.check_output(["openssl", "x509", "-inform", "der"], input=der)
+    if p.returncode:
+        pem = open("/var/sota/client.chained", "rb").read()
+    else:
+        pem = subprocess.check_output(["openssl", "x509", "-inform", "der"], input=p.stdout)
     return pem
 
 


### PR DESCRIPTION
Main goal of this small patch series is to make aws onboarding work
without el2go, support for Amazon Trust Services based end-points
and a small fix.
