### PR TITLE
Awsiot optee updates

### DIFF
--- a/awsiot-optee/aws-iot-setup.py
+++ b/awsiot-optee/aws-iot-setup.py
@@ -166,7 +166,14 @@ if __name__ == "__main__":
     parser.add_argument("--policy-exists",
         help="Use this to specify that the IOT policy is already created (default: %(default)s)",
         action="store_true")
+    parser.add_argument("-r", "--role-name", default=iot_role_name,
+        help="AWS IOT role name (default: %(default)s)")
+    parser.add_argument("-p", "--policy-name", default=iot_policy_name,
+        help="AWS IOT policy name (default: %(default)s)")
     args = parser.parse_args()
+
+    iot_role_name = args.role_name
+    iot_policy_name = args.policy_name
 
     if not args.policy_exists:
         create_iot_policy(iot_policy_name)

--- a/awsiot-optee/aws-iot-setup.py
+++ b/awsiot-optee/aws-iot-setup.py
@@ -65,8 +65,8 @@ def create_iot_policy(name: str):
     ])
 
 
-def get_endpoint() -> str:
-    out = subprocess.check_output(["aws", "iot", "describe-endpoint"])
+def get_endpoint(type: str) -> str:
+    out = subprocess.check_output(["aws", "iot", "describe-endpoint", "--endpoint-type", type])
     return json.loads(out.decode())["endpointAddress"]
 
 
@@ -181,5 +181,6 @@ if __name__ == "__main__":
     for cert, key in factory_cas:
         register_ca(cert, key, reg_conf)
 
-    endpoint = get_endpoint()
-    print(f"= Factory devices can connect to {endpoint} using mTLS!")
+    endpoint_verisign = get_endpoint("iot:Data")
+    endpoint_ats = get_endpoint("iot:Data-ATS")
+    print(f"= Factory devices can connect to endpoint VeriSign: {endpoint_verisign} or endpoint ATS: {endpoint_ats} using mTLS!")

--- a/awsiot-optee/aws-iot-setup.py
+++ b/awsiot-optee/aws-iot-setup.py
@@ -163,10 +163,16 @@ if __name__ == "__main__":
     parser.add_argument("--role-exists",
         help="Use this to specify that the IOT role is already created (default: %(default)s)",
         action="store_true")
+    parser.add_argument("--policy-exists",
+        help="Use this to specify that the IOT policy is already created (default: %(default)s)",
+        action="store_true")
     args = parser.parse_args()
 
-    create_iot_policy(iot_policy_name)
+    if not args.policy_exists:
+        create_iot_policy(iot_policy_name)
+
     role_arn = setup_iot_role(iot_role_name, args.role_exists)
+
     reg_conf = get_registration_config(role_arn, iot_policy_name)
 
     print("= Sleeping a few seconds for IAM to sync")

--- a/awsiot-optee/aws-iot-setup.py
+++ b/awsiot-optee/aws-iot-setup.py
@@ -9,9 +9,9 @@ from time import sleep
 
 
 # You must change the value(s) to match the location of your local PKI files
-factory_cas = (
+factory_cas = [
     ("<PATH_TO_PKI_DIR>/local-ca.pem", "<PATH_TO_PKI_DIR>/local-ca.key"),
-)
+]
 
 # You can change these
 iot_policy_name = "fio-blog"
@@ -170,10 +170,17 @@ if __name__ == "__main__":
         help="AWS IOT role name (default: %(default)s)")
     parser.add_argument("-p", "--policy-name", default=iot_policy_name,
         help="AWS IOT policy name (default: %(default)s)")
+    parser.add_argument("-c", "--factory-ca", nargs=2, action="append",
+        help="Pair of paths pointing to factory CA certificate and private key, in this order. May be specified multiple times.")
     args = parser.parse_args()
 
     iot_role_name = args.role_name
     iot_policy_name = args.policy_name
+
+    if args.factory_ca:
+        factory_cas = []
+        for entry in args.factory_ca:
+            factory_cas.append((entry[0], entry[1]))
 
     if not args.policy_exists:
         create_iot_policy(iot_policy_name)


### PR DESCRIPTION
Improvements for the aws
setup script, such as:
 - ability to specify that IoT role and policy already exist
 - args for paths to factory PKI files
 - role and policy name
 - option to attach role & policy to an el2go generated CA for AWS